### PR TITLE
Update Node.js versions in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 8
-  - 9
   - 10
+  - 12
+  - 14
 matrix:
   fast_finish: true
 services:


### PR DESCRIPTION
Matches Agenda: https://github.com/agenda/agenda/blob/f5b502bcfaae2ad988beb662bc3f0a34bc78db38/.travis.yml#L4-L7

I also enabled Travis CI for now, tho I think we should migrate this to https://github.com/agenda/agendash :-)